### PR TITLE
Fixed bug where HTML templates would not send if only plaintext was e…

### DIFF
--- a/Classes/SendGridEmail.m
+++ b/Classes/SendGridEmail.m
@@ -15,7 +15,6 @@
     self = [super init];
     if (self)
     {
-        self.html = @"";
         self.smtpapi = [[SMTPAPI alloc] init];
         self.bcc = [[NSMutableArray alloc] init];
         [self setInlinePhoto:false];
@@ -90,6 +89,8 @@
     
     if (self.html != nil && self.text == nil)
         self.text = self.html;
+    if (self.html == nil && self.text != nil)
+        self.html = self.text;
     
     //must set the "to" parameter even if X-SMTPAPI tos array is set
     if ([self.smtpapi getTos] != nil && [[self.smtpapi getTos] count] > 0 && self.to == nil)


### PR DESCRIPTION
…ntered

Without this change, SendGrid HTML email templates do not send if no
HTML is explicitly specified by the client